### PR TITLE
Adding subtitle to apps recipe and updating generic recipe for meta tags by name

### DIFF
--- a/generic/generic.json
+++ b/generic/generic.json
@@ -30,6 +30,17 @@
     },
     {
       "command": "store_attribute",
+      "locator": "meta[name='og:title']",
+      "attribute_name": "content",
+      "output": {
+        "name": "TITLE",
+        "type": "string",
+        "show": true
+      },
+      "description": "Saves the title"
+    },
+    {
+      "command": "store_attribute",
       "locator": "meta[property='og:title']",
       "attribute_name": "content",
       "output": {
@@ -41,6 +52,17 @@
     },
     {
       "command": "store_attribute",
+      "locator": "meta[name='og:image']",
+      "attribute_name": "content",
+      "output": {
+        "name": "COVER",
+        "type": "string",
+        "show": true
+      },
+      "description": "Saves the image"
+    },
+    {
+      "command": "store_attribute",
       "locator": "meta[property='og:image']",
       "attribute_name": "content",
       "output": {
@@ -49,6 +71,17 @@
         "show": true
       },
       "description": "Saves the image"
+    },
+    {
+      "command": "store_attribute",
+      "locator": "meta[name='og:description']",
+      "attribute_name": "content",
+      "output": {
+        "name": "DESCRIPTION",
+        "type": "string",
+        "show": true
+      },
+      "description": "Saves the description"
     },
     {
       "command": "store_attribute",

--- a/software/apple.json
+++ b/software/apple.json
@@ -143,6 +143,60 @@
     },
     {
       "command": "json_store_text",
+      "locator": "results.[0].primaryGenreName",
+      "input": "$JSON",
+      "output": {
+        "name":"SUBTITLE1"
+      },
+      "description": "Saves the genre"
+    },
+    {
+      "command": "json_store_text",
+      "locator": "results.[1].primaryGenreName",
+      "input": "$JSON",
+      "output": {
+        "name":"SUBTITLE2"
+      },
+      "description": "Saves the genre"
+    },
+    {
+      "command": "json_store_text",
+      "locator": "results.[2].primaryGenreName",
+      "input": "$JSON",
+      "output": {
+        "name":"SUBTITLE3"
+      },
+      "description": "Saves the genre"
+    },
+    {
+      "command": "json_store_text",
+      "locator": "results.[3].primaryGenreName",
+      "input": "$JSON",
+      "output": {
+        "name":"SUBTITLE4"
+      },
+      "description": "Saves the genre"
+    },
+    {
+      "command": "json_store_text",
+      "locator": "results.[4].primaryGenreName",
+      "input": "$JSON",
+      "output": {
+        "name":"SUBTITLE5"
+      },
+      "description": "Saves the genre"
+    },
+    {
+      "command": "json_store_text",
+      "locator": "results.[5].primaryGenreName",
+      "input": "$JSON",
+      "output": {
+        "name":"SUBTITLE6"
+      },
+      "description": "Saves the genre"
+    },
+    {
+      "command": "json_store_text",
       "locator": "results.[0].trackId",
       "input": "$JSON",
       "output": {


### PR DESCRIPTION
This PR adds a subtitle to the app's recipe, which will be displayed below the app's title. Additionally, it updates the generic recipe to make it work on webpages where meta tags are identified by name instead of property. This will allow the recipe to work in a broader range of websites.

I have tested the changes on several different websites, and they are working as expected. Please let me know if you have any questions or concerns.

Thank you for considering this PR.