### PR TITLE
Improve REGEX on Apple recipes

### DIFF
--- a/albums/apple.json
+++ b/albums/apple.json
@@ -95,7 +95,7 @@
     {
       "command": "regex",
       "input": "$INPUT",
-      "expression": "id([0-9]+)|term=([0-9]+)",
+      "expression": "id([0-9]+)|term=([0-9]+)|([0-9]{4,}$)|([0-9]{4,})\\?",
       "output": {
         "name": "ID"
       },

--- a/podcasts/apple.json
+++ b/podcasts/apple.json
@@ -5,6 +5,7 @@
   "title": "Apple Podcasts",
   "description": "Load podcasts from Apple",
   "urls": [
+    "https://podcasts.apple.com/",
     "https://itunes.apple.com/search?media=podcast",
     "itunes.apple.com",
     "music.apple.com"

--- a/songs/apple.json
+++ b/songs/apple.json
@@ -95,7 +95,7 @@
     {
       "command": "regex",
       "input": "$INPUT",
-      "expression": "id([0-9]+)|term=([0-9]+)",
+      "expression": "id([0-9]+)|term=([0-9]+)|i=([0-9]+)",
       "output": {
         "name": "ID"
       }


### PR DESCRIPTION
Podcasts, albums, and songs were not working due to a change in how Apple introduced the ID on the URL.